### PR TITLE
Fix #48: removing newlines inside a property

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"time"
 )
 
@@ -428,8 +429,10 @@ func (calendar *Calendar) Events() (r []*VEvent) {
 
 func ParseCalendar(r io.Reader) (*Calendar, error) {
 	state := "begin"
+	t, _ := ioutil.ReadAll(r)
+	s := bytes.NewReader(bytes.Replace(t, []byte{0x0D, 0x0A, 0x09}, []byte(""), -1))
 	c := &Calendar{}
-	cs := NewCalendarStream(r)
+	cs := NewCalendarStream(s)
 	cont := true
 	for i := 0; cont; i++ {
 		l, err := cs.ReadLine()


### PR DESCRIPTION
by intercepting iostream in NewCalendar and removing `0x0d 0x0a 0x09`